### PR TITLE
Fix motif annotation selection when using clustered motif dbs (#391)

### DIFF
--- a/src/pyscenic/transform.py
+++ b/src/pyscenic/transform.py
@@ -179,6 +179,9 @@ def module2features_auc1st_impl(
 
     # Find motif annotations for enriched features.
     annotated_features = pd.merge(enriched_features, motif_annotations, how="left", left_index=True, right_index=True)
+    # When using cluster db annotations, keep direct if available otherwise use other (extended)
+    annotated_features = annotated_features.sort_values([COLUMN_NAME_MOTIF_SIMILARITY_QVALUE, COLUMN_NAME_ORTHOLOGOUS_IDENTITY], ascending = [False, True])
+    annotated_features = annotated_features[~annotated_features.index.duplicated(keep='last')]
     annotated_features_idx = (
         pd.notnull(annotated_features[COLUMN_NAME_ANNOTATION])
         if filter_for_annotation


### PR DESCRIPTION
* Fix motif annotation selection when using clustered motif dbs, take direct when available otherwise extended

Co-authored-by: Carmen Bravo <carmen.bravogonzalezblas@kuleuven.be>